### PR TITLE
Update for Firefox to prevent window.event error.

### DIFF
--- a/jGravity.js
+++ b/jGravity.js
@@ -197,18 +197,18 @@ function onDocumentMouseUp() {
 }
 
 // onDocumentMouseMove()
-function onDocumentMouseMove() {
+function onDocumentMouseMove(e) {
 	if (!isRunning)
 		run();
 
-	mouseX = window.event.clientX;
-	mouseY = window.event.clientY;
+	mouseX = e.clientX || window.event.clientX;
+	mouseY = e.clientY || window.event.clientY;
 }
 
 // onElementMouseDown()
-function onElementMouseDown() {
-	mouseOnClick[0] = window.event.clientX;
-	mouseOnClick[1] = window.event.clientY;	
+function onElementMouseDown(e) {
+	mouseOnClick[0] = e.clientX || window.event.clientX;
+	mouseOnClick[1] = e.clientY || window.event.clientY;	
 	return false;
 }
 


### PR DESCRIPTION
Based on this Stack Overflow: http://stackoverflow.com/questions/9813445/why-ff-says-that-window-event-is-undefined-call-function-with-added-event-list
